### PR TITLE
Update v1.4.1: Llama 4 support, dependency updates, and CI improvements

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -23,6 +23,9 @@ jobs:
       - name: Build project and dependencies
         run: npm run build
 
+      - name: Run tests
+        run: npm test
+
       - name: Publish package
         uses: JS-DevTools/npm-publish@v3
         with:

--- a/examples/llama4Multiple.ts
+++ b/examples/llama4Multiple.ts
@@ -1,0 +1,69 @@
+import { buildLlamaLlm } from "../src/index.js"
+import * as dotenv from "dotenv"
+
+dotenv.config()
+
+// Helper function to get environment variable or throw error
+function varOrThrow(key: string): string {
+  if (!process.env[key]) {
+    throw new Error(`Env variable ${key} not defined`)
+  }
+  return process.env[key]
+}
+
+async function main() {
+  console.log("🦙 Llama 4 Multiple Runs Example")
+  console.log("================================\n")
+
+  // Build a Llama 4 model instance
+  const model = buildLlamaLlm("us.meta.llama4-maverick-17b-instruct-v1:0", {
+    awsAccessKey: varOrThrow("AWS_ACCESS_KEY"),
+    awsSecret: varOrThrow("AWS_SECRET"),
+    region: "us-east-1"
+  })
+
+  // Define the prompt and instructions
+  const instructions = "You are a creative AI assistant. Keep your responses brief and engaging."
+  const prompt = "Generate a unique, creative name for a fictional planet and describe one interesting feature about it in a single sentence."
+
+  console.log("Instructions:", instructions)
+  console.log("Prompt:", prompt)
+  console.log("\nRunning 10 iterations...\n")
+
+  // Run the prompt 10 times
+  const results: string[] = []
+  
+  for (let i = 1; i <= 10; i++) {
+    try {
+      console.log(`🌍 Iteration ${i}:`)
+      const startTime = Date.now()
+      
+      const response = await model.getText(prompt, instructions)
+      const endTime = Date.now()
+      
+      console.log(`Response: ${response.text}`)
+      console.log(`Time: ${endTime - startTime}ms`)
+      console.log(`Tokens - Input: ${response.inputTokens}, Output: ${response.outputTokens}`)
+      console.log("---")
+      
+      results.push(response.text)
+    } catch (error) {
+      console.error(`Error on iteration ${i}:`, error)
+    }
+  }
+
+  // Summary
+  console.log("\n📊 Summary")
+  console.log("==========")
+  console.log(`Total successful runs: ${results.length}/10`)
+  console.log("\nAll generated planet names:")
+  results.forEach((result, index) => {
+    console.log(`${index + 1}. ${result}`)
+  })
+}
+
+// Run the main function
+main().catch(error => {
+  console.error("Fatal error:", error)
+  process.exit(1)
+})

--- a/examples/llama4Multiple.ts
+++ b/examples/llama4Multiple.ts
@@ -23,8 +23,15 @@ async function main() {
   })
 
   // Define the prompt and instructions
-  const instructions = "You are a creative AI assistant. Keep your responses brief and engaging."
-  const prompt = "Generate a unique, creative name for a fictional planet and describe one interesting feature about it in a single sentence."
+  const instructions =
+    "You are a creative AI assistant. Please make sure your responses are detailed."
+  const prompt = `Generate a unique, creative name for a fictional planet, describe one interesting feature about it in a single sentence, and give a detailed description of its history. Return your response in a JSON formatted as follows:
+  {
+    "name": "Description goes here",
+    "feature": "Description goes here",
+    "history": "History goes here"
+  }
+  ONLY return the json.`
 
   console.log("Instructions:", instructions)
   console.log("Prompt:", prompt)
@@ -32,20 +39,22 @@ async function main() {
 
   // Run the prompt 10 times
   const results: string[] = []
-  
+
   for (let i = 1; i <= 10; i++) {
     try {
       console.log(`🌍 Iteration ${i}:`)
       const startTime = Date.now()
-      
+
       const response = await model.getText(prompt, instructions)
       const endTime = Date.now()
-      
+
       console.log(`Response: ${response.text}`)
       console.log(`Time: ${endTime - startTime}ms`)
-      console.log(`Tokens - Input: ${response.inputTokens}, Output: ${response.outputTokens}`)
+      console.log(
+        `Tokens - Input: ${response.inputTokens}, Output: ${response.outputTokens}`
+      )
       console.log("---")
-      
+
       results.push(response.text)
     } catch (error) {
       console.error(`Error on iteration ${i}:`, error)

--- a/examples/simpleResponse.ts
+++ b/examples/simpleResponse.ts
@@ -41,7 +41,7 @@ switch (choice) {
     break
   case "3":
     model = buildGeminiLlm(
-      "gemini-2.5-flash-preview-05-20",
+      "gemini-2.5-flash-lite-preview-06-17",
       varOrThrow("GEMINI_KEY")
     )
     break

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,38 +1,38 @@
 {
   "name": "@mfbtech/llm-popular",
-  "version": "1.3.0",
+  "version": "1.4.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@mfbtech/llm-popular",
-      "version": "1.3.0",
+      "version": "1.4.0",
       "license": "MIT",
       "dependencies": {
-        "@anthropic-ai/sdk": "^0.52.0",
-        "@aws-sdk/client-bedrock-runtime": "^3.821.0",
+        "@anthropic-ai/sdk": "^0.54.0",
+        "@aws-sdk/client-bedrock-runtime": "^3.830.0",
         "@google/generative-ai": "^0.24.1",
         "nanoid": "5.1.5",
-        "openai": "^5.1.0"
+        "openai": "^5.5.1"
       },
       "devDependencies": {
         "@mfbtech/llm-api-types": "1.0.0",
         "@rushstack/eslint-config": "4.3.0",
-        "@types/node": "^22.15.29",
-        "@typescript-eslint/eslint-plugin": "^8.33.1",
-        "@typescript-eslint/parser": "^8.33.1",
+        "@types/node": "^22.15.32",
+        "@typescript-eslint/eslint-plugin": "^8.34.1",
+        "@typescript-eslint/parser": "^8.34.1",
         "dotenv": "16.5.0",
         "eslint": "^8.57.1",
         "prettier": "3.5.3",
         "rimraf": "6.0.1",
         "typescript": "5.8.3",
-        "vite-node": "^3.2.1"
+        "vite-node": "^3.2.4"
       }
     },
     "node_modules/@anthropic-ai/sdk": {
-      "version": "0.52.0",
-      "resolved": "https://registry.npmjs.org/@anthropic-ai/sdk/-/sdk-0.52.0.tgz",
-      "integrity": "sha512-d4c+fg+xy9e46c8+YnrrgIQR45CZlAi7PwdzIfDXDM6ACxEZli1/fxhURsq30ZpMZy6LvSkr41jGq5aF5TD7rQ==",
+      "version": "0.54.0",
+      "resolved": "https://registry.npmjs.org/@anthropic-ai/sdk/-/sdk-0.54.0.tgz",
+      "integrity": "sha512-xyoCtHJnt/qg5GG6IgK+UJEndz8h8ljzt/caKXmq3LfBF81nC/BW6E4x2rOWCZcvsLyVW+e8U5mtIr6UCE/kJw==",
       "license": "MIT",
       "bin": {
         "anthropic-ai-sdk": "bin/cli"
@@ -178,28 +178,28 @@
       }
     },
     "node_modules/@aws-sdk/client-bedrock-runtime": {
-      "version": "3.821.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/client-bedrock-runtime/-/client-bedrock-runtime-3.821.0.tgz",
-      "integrity": "sha512-+cxIkQBCa97Yr0vH5j0+bYJSuyJMuVO7IcVfApvobOWenSzm0MAd2EXSigd7+x97570OWBWNHAMiVVxBnBa08Q==",
+      "version": "3.830.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-bedrock-runtime/-/client-bedrock-runtime-3.830.0.tgz",
+      "integrity": "sha512-2f6t0K82CwNdoYYmnuYcyApAAh0H3oOhxF0lydRmPbty56owSC9R2MRzuy1lthLeEmVp0MFaCh17SlFfMKUR1Q==",
       "license": "Apache-2.0",
       "dependencies": {
         "@aws-crypto/sha256-browser": "5.2.0",
         "@aws-crypto/sha256-js": "5.2.0",
-        "@aws-sdk/core": "3.821.0",
-        "@aws-sdk/credential-provider-node": "3.821.0",
+        "@aws-sdk/core": "3.826.0",
+        "@aws-sdk/credential-provider-node": "3.830.0",
         "@aws-sdk/eventstream-handler-node": "3.821.0",
         "@aws-sdk/middleware-eventstream": "3.821.0",
         "@aws-sdk/middleware-host-header": "3.821.0",
         "@aws-sdk/middleware-logger": "3.821.0",
         "@aws-sdk/middleware-recursion-detection": "3.821.0",
-        "@aws-sdk/middleware-user-agent": "3.821.0",
+        "@aws-sdk/middleware-user-agent": "3.828.0",
         "@aws-sdk/region-config-resolver": "3.821.0",
         "@aws-sdk/types": "3.821.0",
-        "@aws-sdk/util-endpoints": "3.821.0",
+        "@aws-sdk/util-endpoints": "3.828.0",
         "@aws-sdk/util-user-agent-browser": "3.821.0",
-        "@aws-sdk/util-user-agent-node": "3.821.0",
+        "@aws-sdk/util-user-agent-node": "3.828.0",
         "@smithy/config-resolver": "^4.1.4",
-        "@smithy/core": "^3.5.1",
+        "@smithy/core": "^3.5.3",
         "@smithy/eventstream-serde-browser": "^4.0.4",
         "@smithy/eventstream-serde-config-resolver": "^4.1.2",
         "@smithy/eventstream-serde-node": "^4.0.4",
@@ -207,21 +207,21 @@
         "@smithy/hash-node": "^4.0.4",
         "@smithy/invalid-dependency": "^4.0.4",
         "@smithy/middleware-content-length": "^4.0.4",
-        "@smithy/middleware-endpoint": "^4.1.9",
-        "@smithy/middleware-retry": "^4.1.10",
+        "@smithy/middleware-endpoint": "^4.1.11",
+        "@smithy/middleware-retry": "^4.1.12",
         "@smithy/middleware-serde": "^4.0.8",
         "@smithy/middleware-stack": "^4.0.4",
         "@smithy/node-config-provider": "^4.1.3",
         "@smithy/node-http-handler": "^4.0.6",
         "@smithy/protocol-http": "^5.1.2",
-        "@smithy/smithy-client": "^4.4.1",
+        "@smithy/smithy-client": "^4.4.3",
         "@smithy/types": "^4.3.1",
         "@smithy/url-parser": "^4.0.4",
         "@smithy/util-base64": "^4.0.0",
         "@smithy/util-body-length-browser": "^4.0.0",
         "@smithy/util-body-length-node": "^4.0.0",
-        "@smithy/util-defaults-mode-browser": "^4.0.17",
-        "@smithy/util-defaults-mode-node": "^4.0.17",
+        "@smithy/util-defaults-mode-browser": "^4.0.19",
+        "@smithy/util-defaults-mode-node": "^4.0.19",
         "@smithy/util-endpoints": "^3.0.6",
         "@smithy/util-middleware": "^4.0.4",
         "@smithy/util-retry": "^4.0.5",
@@ -236,44 +236,44 @@
       }
     },
     "node_modules/@aws-sdk/client-sso": {
-      "version": "3.821.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/client-sso/-/client-sso-3.821.0.tgz",
-      "integrity": "sha512-aDEBZUKUd/+Tvudi0d9KQlqt2OW2P27LATZX0jkNC8yVk4145bAPS04EYoqdKLuyUn/U33DibEOgKUpxZB12jQ==",
+      "version": "3.830.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-sso/-/client-sso-3.830.0.tgz",
+      "integrity": "sha512-5zCEpfI+zwX2SIa258L+TItNbBoAvQQ6w74qdFM6YJufQ1F9tvwjTX8T+eSTT9nsFIvfYnUaGalWwJVfmJUgVQ==",
       "license": "Apache-2.0",
       "dependencies": {
         "@aws-crypto/sha256-browser": "5.2.0",
         "@aws-crypto/sha256-js": "5.2.0",
-        "@aws-sdk/core": "3.821.0",
+        "@aws-sdk/core": "3.826.0",
         "@aws-sdk/middleware-host-header": "3.821.0",
         "@aws-sdk/middleware-logger": "3.821.0",
         "@aws-sdk/middleware-recursion-detection": "3.821.0",
-        "@aws-sdk/middleware-user-agent": "3.821.0",
+        "@aws-sdk/middleware-user-agent": "3.828.0",
         "@aws-sdk/region-config-resolver": "3.821.0",
         "@aws-sdk/types": "3.821.0",
-        "@aws-sdk/util-endpoints": "3.821.0",
+        "@aws-sdk/util-endpoints": "3.828.0",
         "@aws-sdk/util-user-agent-browser": "3.821.0",
-        "@aws-sdk/util-user-agent-node": "3.821.0",
+        "@aws-sdk/util-user-agent-node": "3.828.0",
         "@smithy/config-resolver": "^4.1.4",
-        "@smithy/core": "^3.5.1",
+        "@smithy/core": "^3.5.3",
         "@smithy/fetch-http-handler": "^5.0.4",
         "@smithy/hash-node": "^4.0.4",
         "@smithy/invalid-dependency": "^4.0.4",
         "@smithy/middleware-content-length": "^4.0.4",
-        "@smithy/middleware-endpoint": "^4.1.9",
-        "@smithy/middleware-retry": "^4.1.10",
+        "@smithy/middleware-endpoint": "^4.1.11",
+        "@smithy/middleware-retry": "^4.1.12",
         "@smithy/middleware-serde": "^4.0.8",
         "@smithy/middleware-stack": "^4.0.4",
         "@smithy/node-config-provider": "^4.1.3",
         "@smithy/node-http-handler": "^4.0.6",
         "@smithy/protocol-http": "^5.1.2",
-        "@smithy/smithy-client": "^4.4.1",
+        "@smithy/smithy-client": "^4.4.3",
         "@smithy/types": "^4.3.1",
         "@smithy/url-parser": "^4.0.4",
         "@smithy/util-base64": "^4.0.0",
         "@smithy/util-body-length-browser": "^4.0.0",
         "@smithy/util-body-length-node": "^4.0.0",
-        "@smithy/util-defaults-mode-browser": "^4.0.17",
-        "@smithy/util-defaults-mode-node": "^4.0.17",
+        "@smithy/util-defaults-mode-browser": "^4.0.19",
+        "@smithy/util-defaults-mode-node": "^4.0.19",
         "@smithy/util-endpoints": "^3.0.6",
         "@smithy/util-middleware": "^4.0.4",
         "@smithy/util-retry": "^4.0.5",
@@ -285,20 +285,24 @@
       }
     },
     "node_modules/@aws-sdk/core": {
-      "version": "3.821.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/core/-/core-3.821.0.tgz",
-      "integrity": "sha512-8eB3wKbmfciQFmxFq7hAjy7mXdUs7vBOR5SwT0ZtQBg0Txc18Lc9tMViqqdO6/KU7OukA6ib2IAVSjIJJEN7FQ==",
+      "version": "3.826.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/core/-/core-3.826.0.tgz",
+      "integrity": "sha512-BGbQYzWj3ps+dblq33FY5tz/SsgJCcXX0zjQlSC07tYvU1jHTUvsefphyig+fY38xZ4wdKjbTop+KUmXUYrOXw==",
       "license": "Apache-2.0",
       "dependencies": {
         "@aws-sdk/types": "3.821.0",
-        "@smithy/core": "^3.5.1",
+        "@aws-sdk/xml-builder": "3.821.0",
+        "@smithy/core": "^3.5.3",
         "@smithy/node-config-provider": "^4.1.3",
         "@smithy/property-provider": "^4.0.4",
         "@smithy/protocol-http": "^5.1.2",
         "@smithy/signature-v4": "^5.1.2",
-        "@smithy/smithy-client": "^4.4.1",
+        "@smithy/smithy-client": "^4.4.3",
         "@smithy/types": "^4.3.1",
+        "@smithy/util-base64": "^4.0.0",
+        "@smithy/util-body-length-browser": "^4.0.0",
         "@smithy/util-middleware": "^4.0.4",
+        "@smithy/util-utf8": "^4.0.0",
         "fast-xml-parser": "4.4.1",
         "tslib": "^2.6.2"
       },
@@ -307,12 +311,12 @@
       }
     },
     "node_modules/@aws-sdk/credential-provider-env": {
-      "version": "3.821.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-env/-/credential-provider-env-3.821.0.tgz",
-      "integrity": "sha512-C+s/A72pd7CXwEsJj9+Uq9T726iIfIF18hGRY8o82xcIEfOyakiPnlisku8zZOaAu+jm0CihbbYN4NyYNQ+HZQ==",
+      "version": "3.826.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-env/-/credential-provider-env-3.826.0.tgz",
+      "integrity": "sha512-DK3pQY8+iKK3MGDdC3uOZQ2psU01obaKlTYhEwNu4VWzgwQL4Vi3sWj4xSWGEK41vqZxiRLq6fOq7ysRI+qEZA==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/core": "3.821.0",
+        "@aws-sdk/core": "3.826.0",
         "@aws-sdk/types": "3.821.0",
         "@smithy/property-provider": "^4.0.4",
         "@smithy/types": "^4.3.1",
@@ -323,18 +327,18 @@
       }
     },
     "node_modules/@aws-sdk/credential-provider-http": {
-      "version": "3.821.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-http/-/credential-provider-http-3.821.0.tgz",
-      "integrity": "sha512-gIRzTLnAsRfRSNarCag7G7rhcHagz4x5nNTWRihQs5cwTOghEExDy7Tj5m4TEkv3dcTAsNn+l4tnR4nZXo6R+Q==",
+      "version": "3.826.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-http/-/credential-provider-http-3.826.0.tgz",
+      "integrity": "sha512-N+IVZBh+yx/9GbMZTKO/gErBi/FYZQtcFRItoLbY+6WU+0cSWyZYfkoeOxHmQV3iX9k65oljERIWUmL9x6OSQg==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/core": "3.821.0",
+        "@aws-sdk/core": "3.826.0",
         "@aws-sdk/types": "3.821.0",
         "@smithy/fetch-http-handler": "^5.0.4",
         "@smithy/node-http-handler": "^4.0.6",
         "@smithy/property-provider": "^4.0.4",
         "@smithy/protocol-http": "^5.1.2",
-        "@smithy/smithy-client": "^4.4.1",
+        "@smithy/smithy-client": "^4.4.3",
         "@smithy/types": "^4.3.1",
         "@smithy/util-stream": "^4.2.2",
         "tslib": "^2.6.2"
@@ -344,18 +348,18 @@
       }
     },
     "node_modules/@aws-sdk/credential-provider-ini": {
-      "version": "3.821.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-ini/-/credential-provider-ini-3.821.0.tgz",
-      "integrity": "sha512-VRTrmsca8kBHtY1tTek1ce+XkK/H0fzodBKcilM/qXjTyumMHPAzVAxKZfSvGC+28/pXyQzhOEyxZfw7giCiWA==",
+      "version": "3.830.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-ini/-/credential-provider-ini-3.830.0.tgz",
+      "integrity": "sha512-zeQenzvh8JRY5nULd8izdjVGoCM1tgsVVsrLSwDkHxZTTW0hW/bmOmXfvdaE0wDdomXW7m2CkQDSmP7XdvNXZg==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/core": "3.821.0",
-        "@aws-sdk/credential-provider-env": "3.821.0",
-        "@aws-sdk/credential-provider-http": "3.821.0",
-        "@aws-sdk/credential-provider-process": "3.821.0",
-        "@aws-sdk/credential-provider-sso": "3.821.0",
-        "@aws-sdk/credential-provider-web-identity": "3.821.0",
-        "@aws-sdk/nested-clients": "3.821.0",
+        "@aws-sdk/core": "3.826.0",
+        "@aws-sdk/credential-provider-env": "3.826.0",
+        "@aws-sdk/credential-provider-http": "3.826.0",
+        "@aws-sdk/credential-provider-process": "3.826.0",
+        "@aws-sdk/credential-provider-sso": "3.830.0",
+        "@aws-sdk/credential-provider-web-identity": "3.830.0",
+        "@aws-sdk/nested-clients": "3.830.0",
         "@aws-sdk/types": "3.821.0",
         "@smithy/credential-provider-imds": "^4.0.6",
         "@smithy/property-provider": "^4.0.4",
@@ -368,17 +372,17 @@
       }
     },
     "node_modules/@aws-sdk/credential-provider-node": {
-      "version": "3.821.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-node/-/credential-provider-node-3.821.0.tgz",
-      "integrity": "sha512-oBgbcgOXWMgknAfhIdTeHSSVIv+k2LXN9oTbxu1r++o4WWBWrEQ8mHU0Zo9dfr7Uaoqi3pezYZznsBkXnMLEOg==",
+      "version": "3.830.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-node/-/credential-provider-node-3.830.0.tgz",
+      "integrity": "sha512-X/2LrTgwtK1pkWrvofxQBI8VTi6QVLtSMpsKKPPnJQ0vgqC0e4czSIs3ZxiEsOkCBaQ2usXSiKyh0ccsQ6k2OA==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/credential-provider-env": "3.821.0",
-        "@aws-sdk/credential-provider-http": "3.821.0",
-        "@aws-sdk/credential-provider-ini": "3.821.0",
-        "@aws-sdk/credential-provider-process": "3.821.0",
-        "@aws-sdk/credential-provider-sso": "3.821.0",
-        "@aws-sdk/credential-provider-web-identity": "3.821.0",
+        "@aws-sdk/credential-provider-env": "3.826.0",
+        "@aws-sdk/credential-provider-http": "3.826.0",
+        "@aws-sdk/credential-provider-ini": "3.830.0",
+        "@aws-sdk/credential-provider-process": "3.826.0",
+        "@aws-sdk/credential-provider-sso": "3.830.0",
+        "@aws-sdk/credential-provider-web-identity": "3.830.0",
         "@aws-sdk/types": "3.821.0",
         "@smithy/credential-provider-imds": "^4.0.6",
         "@smithy/property-provider": "^4.0.4",
@@ -391,12 +395,12 @@
       }
     },
     "node_modules/@aws-sdk/credential-provider-process": {
-      "version": "3.821.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-process/-/credential-provider-process-3.821.0.tgz",
-      "integrity": "sha512-e18ucfqKB3ICNj5RP/FEdvUfhVK6E9MALOsl8pKP13mwegug46p/1BsZWACD5n+Zf9ViiiHxIO7td03zQixfwA==",
+      "version": "3.826.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-process/-/credential-provider-process-3.826.0.tgz",
+      "integrity": "sha512-kURrc4amu3NLtw1yZw7EoLNEVhmOMRUTs+chaNcmS+ERm3yK0nKjaJzmKahmwlTQTSl3wJ8jjK7x962VPo+zWw==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/core": "3.821.0",
+        "@aws-sdk/core": "3.826.0",
         "@aws-sdk/types": "3.821.0",
         "@smithy/property-provider": "^4.0.4",
         "@smithy/shared-ini-file-loader": "^4.0.4",
@@ -408,14 +412,14 @@
       }
     },
     "node_modules/@aws-sdk/credential-provider-sso": {
-      "version": "3.821.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-sso/-/credential-provider-sso-3.821.0.tgz",
-      "integrity": "sha512-Dt+pheBLom4O/egO4L75/72k9C1qtUOLl0F0h6lmqZe4Mvhz+wDtjoO/MdGC/P1q0kcIX/bBKr0NQ3cIvAH8pA==",
+      "version": "3.830.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-sso/-/credential-provider-sso-3.830.0.tgz",
+      "integrity": "sha512-+VdRpZmfekzpySqZikAKx6l5ndnLGluioIgUG4ZznrButgFD/iogzFtGmBDFB3ZLViX1l4pMXru0zFwJEZT21Q==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/client-sso": "3.821.0",
-        "@aws-sdk/core": "3.821.0",
-        "@aws-sdk/token-providers": "3.821.0",
+        "@aws-sdk/client-sso": "3.830.0",
+        "@aws-sdk/core": "3.826.0",
+        "@aws-sdk/token-providers": "3.830.0",
         "@aws-sdk/types": "3.821.0",
         "@smithy/property-provider": "^4.0.4",
         "@smithy/shared-ini-file-loader": "^4.0.4",
@@ -427,13 +431,13 @@
       }
     },
     "node_modules/@aws-sdk/credential-provider-web-identity": {
-      "version": "3.821.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-web-identity/-/credential-provider-web-identity-3.821.0.tgz",
-      "integrity": "sha512-FF5wnRJkxSQaCVVvWNv53K1MhTMgH8d+O+MHTbkv51gVIgVATrtfFQMKBLcEAxzXrgAliIO3LiNv+1TqqBZ+BA==",
+      "version": "3.830.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-web-identity/-/credential-provider-web-identity-3.830.0.tgz",
+      "integrity": "sha512-hPYrKsZeeOdLROJ59T6Y8yZ0iwC/60L3qhZXjapBFjbqBtMaQiMTI645K6xVXBioA6vxXq7B4aLOhYqk6Fy/Ww==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/core": "3.821.0",
-        "@aws-sdk/nested-clients": "3.821.0",
+        "@aws-sdk/core": "3.826.0",
+        "@aws-sdk/nested-clients": "3.830.0",
         "@aws-sdk/types": "3.821.0",
         "@smithy/property-provider": "^4.0.4",
         "@smithy/types": "^4.3.1",
@@ -518,15 +522,15 @@
       }
     },
     "node_modules/@aws-sdk/middleware-user-agent": {
-      "version": "3.821.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-user-agent/-/middleware-user-agent-3.821.0.tgz",
-      "integrity": "sha512-rw8q3TxygMg3VrofN04QyWVCCyGwz3bVthYmBZZseENPWG3Krz1OCKcyqjkTcAxMQlEywOske+GIiOasGKnJ3w==",
+      "version": "3.828.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-user-agent/-/middleware-user-agent-3.828.0.tgz",
+      "integrity": "sha512-nixvI/SETXRdmrVab4D9LvXT3lrXkwAWGWk2GVvQvzlqN1/M/RfClj+o37Sn4FqRkGH9o9g7Fqb1YqZ4mqDAtA==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/core": "3.821.0",
+        "@aws-sdk/core": "3.826.0",
         "@aws-sdk/types": "3.821.0",
-        "@aws-sdk/util-endpoints": "3.821.0",
-        "@smithy/core": "^3.5.1",
+        "@aws-sdk/util-endpoints": "3.828.0",
+        "@smithy/core": "^3.5.3",
         "@smithy/protocol-http": "^5.1.2",
         "@smithy/types": "^4.3.1",
         "tslib": "^2.6.2"
@@ -536,44 +540,44 @@
       }
     },
     "node_modules/@aws-sdk/nested-clients": {
-      "version": "3.821.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/nested-clients/-/nested-clients-3.821.0.tgz",
-      "integrity": "sha512-2IuHcUsWw44ftSEDYU4dvktTEqgyDvkOcfpoGC/UmT4Qo6TVCP3U5tWEGpNK9nN+7nLvekruxxG/jaMt5/oWVw==",
+      "version": "3.830.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/nested-clients/-/nested-clients-3.830.0.tgz",
+      "integrity": "sha512-5N5YTlBr1vtxf7+t+UaIQ625KEAmm7fY9o1e3MgGOi/paBoI0+axr3ud24qLIy0NSzFlAHEaxUSWxcERNjIoZw==",
       "license": "Apache-2.0",
       "dependencies": {
         "@aws-crypto/sha256-browser": "5.2.0",
         "@aws-crypto/sha256-js": "5.2.0",
-        "@aws-sdk/core": "3.821.0",
+        "@aws-sdk/core": "3.826.0",
         "@aws-sdk/middleware-host-header": "3.821.0",
         "@aws-sdk/middleware-logger": "3.821.0",
         "@aws-sdk/middleware-recursion-detection": "3.821.0",
-        "@aws-sdk/middleware-user-agent": "3.821.0",
+        "@aws-sdk/middleware-user-agent": "3.828.0",
         "@aws-sdk/region-config-resolver": "3.821.0",
         "@aws-sdk/types": "3.821.0",
-        "@aws-sdk/util-endpoints": "3.821.0",
+        "@aws-sdk/util-endpoints": "3.828.0",
         "@aws-sdk/util-user-agent-browser": "3.821.0",
-        "@aws-sdk/util-user-agent-node": "3.821.0",
+        "@aws-sdk/util-user-agent-node": "3.828.0",
         "@smithy/config-resolver": "^4.1.4",
-        "@smithy/core": "^3.5.1",
+        "@smithy/core": "^3.5.3",
         "@smithy/fetch-http-handler": "^5.0.4",
         "@smithy/hash-node": "^4.0.4",
         "@smithy/invalid-dependency": "^4.0.4",
         "@smithy/middleware-content-length": "^4.0.4",
-        "@smithy/middleware-endpoint": "^4.1.9",
-        "@smithy/middleware-retry": "^4.1.10",
+        "@smithy/middleware-endpoint": "^4.1.11",
+        "@smithy/middleware-retry": "^4.1.12",
         "@smithy/middleware-serde": "^4.0.8",
         "@smithy/middleware-stack": "^4.0.4",
         "@smithy/node-config-provider": "^4.1.3",
         "@smithy/node-http-handler": "^4.0.6",
         "@smithy/protocol-http": "^5.1.2",
-        "@smithy/smithy-client": "^4.4.1",
+        "@smithy/smithy-client": "^4.4.3",
         "@smithy/types": "^4.3.1",
         "@smithy/url-parser": "^4.0.4",
         "@smithy/util-base64": "^4.0.0",
         "@smithy/util-body-length-browser": "^4.0.0",
         "@smithy/util-body-length-node": "^4.0.0",
-        "@smithy/util-defaults-mode-browser": "^4.0.17",
-        "@smithy/util-defaults-mode-node": "^4.0.17",
+        "@smithy/util-defaults-mode-browser": "^4.0.19",
+        "@smithy/util-defaults-mode-node": "^4.0.19",
         "@smithy/util-endpoints": "^3.0.6",
         "@smithy/util-middleware": "^4.0.4",
         "@smithy/util-retry": "^4.0.5",
@@ -602,13 +606,13 @@
       }
     },
     "node_modules/@aws-sdk/token-providers": {
-      "version": "3.821.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/token-providers/-/token-providers-3.821.0.tgz",
-      "integrity": "sha512-qJ7wgKhdxGbPg718zWXbCYKDuSWZNU3TSw64hPRW6FtbZrIyZxObpiTKC6DKwfsVoZZhHEoP/imGykN1OdOTJA==",
+      "version": "3.830.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/token-providers/-/token-providers-3.830.0.tgz",
+      "integrity": "sha512-aJ4guFwj92nV9D+EgJPaCFKK0I3y2uMchiDfh69Zqnmwfxxxfxat6F79VA7PS0BdbjRfhLbn+Ghjftnomu2c1g==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/core": "3.821.0",
-        "@aws-sdk/nested-clients": "3.821.0",
+        "@aws-sdk/core": "3.826.0",
+        "@aws-sdk/nested-clients": "3.830.0",
         "@aws-sdk/types": "3.821.0",
         "@smithy/property-provider": "^4.0.4",
         "@smithy/shared-ini-file-loader": "^4.0.4",
@@ -633,9 +637,9 @@
       }
     },
     "node_modules/@aws-sdk/util-endpoints": {
-      "version": "3.821.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-endpoints/-/util-endpoints-3.821.0.tgz",
-      "integrity": "sha512-Uknt/zUZnLE76zaAAPEayOeF5/4IZ2puTFXvcSCWHsi9m3tqbb9UozlnlVqvCZLCRWfQryZQoG2W4XSS3qgk5A==",
+      "version": "3.828.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-endpoints/-/util-endpoints-3.828.0.tgz",
+      "integrity": "sha512-RvKch111SblqdkPzg3oCIdlGxlQs+k+P7Etory9FmxPHyPDvsP1j1c74PmgYqtzzMWmoXTjd+c9naUHh9xG8xg==",
       "license": "Apache-2.0",
       "dependencies": {
         "@aws-sdk/types": "3.821.0",
@@ -672,12 +676,12 @@
       }
     },
     "node_modules/@aws-sdk/util-user-agent-node": {
-      "version": "3.821.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-node/-/util-user-agent-node-3.821.0.tgz",
-      "integrity": "sha512-YwMXc9EvuzJgnLBTyiQly2juPujXwDgcMHB0iSN92tHe7Dd1jJ1feBmTgdClaaqCeHFUaFpw+3JU/ZUJ6LjR+A==",
+      "version": "3.828.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-node/-/util-user-agent-node-3.828.0.tgz",
+      "integrity": "sha512-LdN6fTBzTlQmc8O8f1wiZN0qF3yBWVGis7NwpWK7FUEzP9bEZRxYfIkV9oV9zpt6iNRze1SedK3JQVB/udxBoA==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/middleware-user-agent": "3.821.0",
+        "@aws-sdk/middleware-user-agent": "3.828.0",
         "@aws-sdk/types": "3.821.0",
         "@smithy/node-config-provider": "^4.1.3",
         "@smithy/types": "^4.3.1",
@@ -693,6 +697,19 @@
         "aws-crt": {
           "optional": true
         }
+      }
+    },
+    "node_modules/@aws-sdk/xml-builder": {
+      "version": "3.821.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/xml-builder/-/xml-builder-3.821.0.tgz",
+      "integrity": "sha512-DIIotRnefVL6DiaHtO6/21DhJ4JZnnIwdNbpwiAhdt/AVbttcE4yw925gsjur0OGv5BTYXQXU3YnANBYnZjuQA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/types": "^4.3.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
       }
     },
     "node_modules/@esbuild/aix-ppc64": {
@@ -1953,9 +1970,9 @@
       }
     },
     "node_modules/@smithy/core": {
-      "version": "3.5.1",
-      "resolved": "https://registry.npmjs.org/@smithy/core/-/core-3.5.1.tgz",
-      "integrity": "sha512-xSw7bZEFKwOKrm/iv8e2BLt2ur98YZdrRD6nII8ditQeUsY2Q1JmIQ0rpILOhaLKYxxG2ivnoOpokzr9qLyDWA==",
+      "version": "3.5.3",
+      "resolved": "https://registry.npmjs.org/@smithy/core/-/core-3.5.3.tgz",
+      "integrity": "sha512-xa5byV9fEguZNofCclv6v9ra0FYh5FATQW/da7FQUVTic94DfrN/NvmKZjrMyzbpqfot9ZjBaO8U1UeTbmSLuA==",
       "license": "Apache-2.0",
       "dependencies": {
         "@smithy/middleware-serde": "^4.0.8",
@@ -2129,12 +2146,12 @@
       }
     },
     "node_modules/@smithy/middleware-endpoint": {
-      "version": "4.1.9",
-      "resolved": "https://registry.npmjs.org/@smithy/middleware-endpoint/-/middleware-endpoint-4.1.9.tgz",
-      "integrity": "sha512-AjDgX4UjORLltD/LZCBQTwjQqEfyrx/GeDTHcYLzIgf87pIT70tMWnN87NQpJru1K4ITirY2htSOxNECZJCBOg==",
+      "version": "4.1.11",
+      "resolved": "https://registry.npmjs.org/@smithy/middleware-endpoint/-/middleware-endpoint-4.1.11.tgz",
+      "integrity": "sha512-zDogwtRLzKl58lVS8wPcARevFZNBOOqnmzWWxVe9XiaXU2CADFjvJ9XfNibgkOWs08sxLuSr81NrpY4mgp9OwQ==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/core": "^3.5.1",
+        "@smithy/core": "^3.5.3",
         "@smithy/middleware-serde": "^4.0.8",
         "@smithy/node-config-provider": "^4.1.3",
         "@smithy/shared-ini-file-loader": "^4.0.4",
@@ -2148,15 +2165,15 @@
       }
     },
     "node_modules/@smithy/middleware-retry": {
-      "version": "4.1.10",
-      "resolved": "https://registry.npmjs.org/@smithy/middleware-retry/-/middleware-retry-4.1.10.tgz",
-      "integrity": "sha512-RyhcA3sZIIvAo6r48b2Nx2qfg0OnyohlaV0fw415xrQyx5HQ2bvHl9vs/WBiDXIP49mCfws5wX4308c9Pi/isw==",
+      "version": "4.1.12",
+      "resolved": "https://registry.npmjs.org/@smithy/middleware-retry/-/middleware-retry-4.1.12.tgz",
+      "integrity": "sha512-wvIH70c4e91NtRxdaLZF+mbLZ/HcC6yg7ySKUiufL6ESp6zJUSnJucZ309AvG9nqCFHSRB5I6T3Ez1Q9wCh0Ww==",
       "license": "Apache-2.0",
       "dependencies": {
         "@smithy/node-config-provider": "^4.1.3",
         "@smithy/protocol-http": "^5.1.2",
         "@smithy/service-error-classification": "^4.0.5",
-        "@smithy/smithy-client": "^4.4.1",
+        "@smithy/smithy-client": "^4.4.3",
         "@smithy/types": "^4.3.1",
         "@smithy/util-middleware": "^4.0.4",
         "@smithy/util-retry": "^4.0.5",
@@ -2323,13 +2340,13 @@
       }
     },
     "node_modules/@smithy/smithy-client": {
-      "version": "4.4.1",
-      "resolved": "https://registry.npmjs.org/@smithy/smithy-client/-/smithy-client-4.4.1.tgz",
-      "integrity": "sha512-XPbcHRfd0iwx8dY5XCBCGyI7uweMW0oezYezxXcG8ANgvZ5YPuC6Ylh+n0bTHpdU3SCMZOnhzgVklYz+p3fIhw==",
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/@smithy/smithy-client/-/smithy-client-4.4.3.tgz",
+      "integrity": "sha512-xxzNYgA0HD6ETCe5QJubsxP0hQH3QK3kbpJz3QrosBCuIWyEXLR/CO5hFb2OeawEKUxMNhz3a1nuJNN2np2RMA==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/core": "^3.5.1",
-        "@smithy/middleware-endpoint": "^4.1.9",
+        "@smithy/core": "^3.5.3",
+        "@smithy/middleware-endpoint": "^4.1.11",
         "@smithy/middleware-stack": "^4.0.4",
         "@smithy/protocol-http": "^5.1.2",
         "@smithy/types": "^4.3.1",
@@ -2430,13 +2447,13 @@
       }
     },
     "node_modules/@smithy/util-defaults-mode-browser": {
-      "version": "4.0.17",
-      "resolved": "https://registry.npmjs.org/@smithy/util-defaults-mode-browser/-/util-defaults-mode-browser-4.0.17.tgz",
-      "integrity": "sha512-HXq5181qnXmIwB7VrwqwP8rsJybHMoYuJnNoXy4PROs2pfSI4sWDMASF2i+7Lo+u64Y6xowhegcdxczowgJtZg==",
+      "version": "4.0.19",
+      "resolved": "https://registry.npmjs.org/@smithy/util-defaults-mode-browser/-/util-defaults-mode-browser-4.0.19.tgz",
+      "integrity": "sha512-mvLMh87xSmQrV5XqnUYEPoiFFeEGYeAKIDDKdhE2ahqitm8OHM3aSvhqL6rrK6wm1brIk90JhxDf5lf2hbrLbQ==",
       "license": "Apache-2.0",
       "dependencies": {
         "@smithy/property-provider": "^4.0.4",
-        "@smithy/smithy-client": "^4.4.1",
+        "@smithy/smithy-client": "^4.4.3",
         "@smithy/types": "^4.3.1",
         "bowser": "^2.11.0",
         "tslib": "^2.6.2"
@@ -2446,16 +2463,16 @@
       }
     },
     "node_modules/@smithy/util-defaults-mode-node": {
-      "version": "4.0.17",
-      "resolved": "https://registry.npmjs.org/@smithy/util-defaults-mode-node/-/util-defaults-mode-node-4.0.17.tgz",
-      "integrity": "sha512-RfU2A5LjFhEHw4Nwl1GZNitK4AUWu5jGtigAUDoQtfDUvYHpQxcuLw2QGAdKDtKRflIiHSZ8wXBDR36H9R2Ang==",
+      "version": "4.0.19",
+      "resolved": "https://registry.npmjs.org/@smithy/util-defaults-mode-node/-/util-defaults-mode-node-4.0.19.tgz",
+      "integrity": "sha512-8tYnx+LUfj6m+zkUUIrIQJxPM1xVxfRBvoGHua7R/i6qAxOMjqR6CpEpDwKoIs1o0+hOjGvkKE23CafKL0vJ9w==",
       "license": "Apache-2.0",
       "dependencies": {
         "@smithy/config-resolver": "^4.1.4",
         "@smithy/credential-provider-imds": "^4.0.6",
         "@smithy/node-config-provider": "^4.1.3",
         "@smithy/property-provider": "^4.0.4",
-        "@smithy/smithy-client": "^4.4.1",
+        "@smithy/smithy-client": "^4.4.3",
         "@smithy/types": "^4.3.1",
         "tslib": "^2.6.2"
       },
@@ -2568,9 +2585,9 @@
       "license": "MIT"
     },
     "node_modules/@types/node": {
-      "version": "22.15.29",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.15.29.tgz",
-      "integrity": "sha512-LNdjOkUDlU1RZb8e1kOIUpN1qQUlzGkEtbVNo53vbrwDg5om6oduhm4SiUaPW5ASTXhAiP0jInWG8Qx9fVlOeQ==",
+      "version": "22.15.32",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.15.32.tgz",
+      "integrity": "sha512-3jigKqgSjsH6gYZv2nEsqdXfZqIFGAV36XYYjf9KGZ3PSG+IhLecqPnI310RvjutyMwifE2hhhNEklOUrvx/wA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -2591,17 +2608,17 @@
       "license": "MIT"
     },
     "node_modules/@typescript-eslint/eslint-plugin": {
-      "version": "8.33.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-8.33.1.tgz",
-      "integrity": "sha512-TDCXj+YxLgtvxvFlAvpoRv9MAncDLBV2oT9Bd7YBGC/b/sEURoOYuIwLI99rjWOfY3QtDzO+mk0n4AmdFExW8A==",
+      "version": "8.34.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-8.34.1.tgz",
+      "integrity": "sha512-STXcN6ebF6li4PxwNeFnqF8/2BNDvBupf2OPx2yWNzr6mKNGF7q49VM00Pz5FaomJyqvbXpY6PhO+T9w139YEQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@eslint-community/regexpp": "^4.10.0",
-        "@typescript-eslint/scope-manager": "8.33.1",
-        "@typescript-eslint/type-utils": "8.33.1",
-        "@typescript-eslint/utils": "8.33.1",
-        "@typescript-eslint/visitor-keys": "8.33.1",
+        "@typescript-eslint/scope-manager": "8.34.1",
+        "@typescript-eslint/type-utils": "8.34.1",
+        "@typescript-eslint/utils": "8.34.1",
+        "@typescript-eslint/visitor-keys": "8.34.1",
         "graphemer": "^1.4.0",
         "ignore": "^7.0.0",
         "natural-compare": "^1.4.0",
@@ -2615,22 +2632,22 @@
         "url": "https://opencollective.com/typescript-eslint"
       },
       "peerDependencies": {
-        "@typescript-eslint/parser": "^8.33.1",
+        "@typescript-eslint/parser": "^8.34.1",
         "eslint": "^8.57.0 || ^9.0.0",
         "typescript": ">=4.8.4 <5.9.0"
       }
     },
     "node_modules/@typescript-eslint/eslint-plugin/node_modules/@typescript-eslint/typescript-estree": {
-      "version": "8.33.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-8.33.1.tgz",
-      "integrity": "sha512-+s9LYcT8LWjdYWu7IWs7FvUxpQ/DGkdjZeE/GGulHvv8rvYwQvVaUZ6DE+j5x/prADUgSbbCWZ2nPI3usuVeOA==",
+      "version": "8.34.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-8.34.1.tgz",
+      "integrity": "sha512-rjCNqqYPuMUF5ODD+hWBNmOitjBWghkGKJg6hiCHzUvXRy6rK22Jd3rwbP2Xi+R7oYVvIKhokHVhH41BxPV5mA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/project-service": "8.33.1",
-        "@typescript-eslint/tsconfig-utils": "8.33.1",
-        "@typescript-eslint/types": "8.33.1",
-        "@typescript-eslint/visitor-keys": "8.33.1",
+        "@typescript-eslint/project-service": "8.34.1",
+        "@typescript-eslint/tsconfig-utils": "8.34.1",
+        "@typescript-eslint/types": "8.34.1",
+        "@typescript-eslint/visitor-keys": "8.34.1",
         "debug": "^4.3.4",
         "fast-glob": "^3.3.2",
         "is-glob": "^4.0.3",
@@ -2650,16 +2667,16 @@
       }
     },
     "node_modules/@typescript-eslint/eslint-plugin/node_modules/@typescript-eslint/utils": {
-      "version": "8.33.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-8.33.1.tgz",
-      "integrity": "sha512-52HaBiEQUaRYqAXpfzWSR2U3gxk92Kw006+xZpElaPMg3C4PgM+A5LqwoQI1f9E5aZ/qlxAZxzm42WX+vn92SQ==",
+      "version": "8.34.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-8.34.1.tgz",
+      "integrity": "sha512-mqOwUdZ3KjtGk7xJJnLbHxTuWVn3GO2WZZuM+Slhkun4+qthLdXx32C8xIXbO1kfCECb3jIs3eoxK3eryk7aoQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.7.0",
-        "@typescript-eslint/scope-manager": "8.33.1",
-        "@typescript-eslint/types": "8.33.1",
-        "@typescript-eslint/typescript-estree": "8.33.1"
+        "@typescript-eslint/scope-manager": "8.34.1",
+        "@typescript-eslint/types": "8.34.1",
+        "@typescript-eslint/typescript-estree": "8.34.1"
       },
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -2684,16 +2701,16 @@
       }
     },
     "node_modules/@typescript-eslint/parser": {
-      "version": "8.33.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-8.33.1.tgz",
-      "integrity": "sha512-qwxv6dq682yVvgKKp2qWwLgRbscDAYktPptK4JPojCwwi3R9cwrvIxS4lvBpzmcqzR4bdn54Z0IG1uHFskW4dA==",
+      "version": "8.34.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-8.34.1.tgz",
+      "integrity": "sha512-4O3idHxhyzjClSMJ0a29AcoK0+YwnEqzI6oz3vlRf3xw0zbzt15MzXwItOlnr5nIth6zlY2RENLsOPvhyrKAQA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/scope-manager": "8.33.1",
-        "@typescript-eslint/types": "8.33.1",
-        "@typescript-eslint/typescript-estree": "8.33.1",
-        "@typescript-eslint/visitor-keys": "8.33.1",
+        "@typescript-eslint/scope-manager": "8.34.1",
+        "@typescript-eslint/types": "8.34.1",
+        "@typescript-eslint/typescript-estree": "8.34.1",
+        "@typescript-eslint/visitor-keys": "8.34.1",
         "debug": "^4.3.4"
       },
       "engines": {
@@ -2709,16 +2726,16 @@
       }
     },
     "node_modules/@typescript-eslint/parser/node_modules/@typescript-eslint/typescript-estree": {
-      "version": "8.33.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-8.33.1.tgz",
-      "integrity": "sha512-+s9LYcT8LWjdYWu7IWs7FvUxpQ/DGkdjZeE/GGulHvv8rvYwQvVaUZ6DE+j5x/prADUgSbbCWZ2nPI3usuVeOA==",
+      "version": "8.34.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-8.34.1.tgz",
+      "integrity": "sha512-rjCNqqYPuMUF5ODD+hWBNmOitjBWghkGKJg6hiCHzUvXRy6rK22Jd3rwbP2Xi+R7oYVvIKhokHVhH41BxPV5mA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/project-service": "8.33.1",
-        "@typescript-eslint/tsconfig-utils": "8.33.1",
-        "@typescript-eslint/types": "8.33.1",
-        "@typescript-eslint/visitor-keys": "8.33.1",
+        "@typescript-eslint/project-service": "8.34.1",
+        "@typescript-eslint/tsconfig-utils": "8.34.1",
+        "@typescript-eslint/types": "8.34.1",
+        "@typescript-eslint/visitor-keys": "8.34.1",
         "debug": "^4.3.4",
         "fast-glob": "^3.3.2",
         "is-glob": "^4.0.3",
@@ -2738,14 +2755,14 @@
       }
     },
     "node_modules/@typescript-eslint/project-service": {
-      "version": "8.33.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/project-service/-/project-service-8.33.1.tgz",
-      "integrity": "sha512-DZR0efeNklDIHHGRpMpR5gJITQpu6tLr9lDJnKdONTC7vvzOlLAG/wcfxcdxEWrbiZApcoBCzXqU/Z458Za5Iw==",
+      "version": "8.34.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/project-service/-/project-service-8.34.1.tgz",
+      "integrity": "sha512-nuHlOmFZfuRwLJKDGQOVc0xnQrAmuq1Mj/ISou5044y1ajGNp2BNliIqp7F2LPQ5sForz8lempMFCovfeS1XoA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/tsconfig-utils": "^8.33.1",
-        "@typescript-eslint/types": "^8.33.1",
+        "@typescript-eslint/tsconfig-utils": "^8.34.1",
+        "@typescript-eslint/types": "^8.34.1",
         "debug": "^4.3.4"
       },
       "engines": {
@@ -2760,14 +2777,14 @@
       }
     },
     "node_modules/@typescript-eslint/scope-manager": {
-      "version": "8.33.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-8.33.1.tgz",
-      "integrity": "sha512-dM4UBtgmzHR9bS0Rv09JST0RcHYearoEoo3pG5B6GoTR9XcyeqX87FEhPo+5kTvVfKCvfHaHrcgeJQc6mrDKrA==",
+      "version": "8.34.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-8.34.1.tgz",
+      "integrity": "sha512-beu6o6QY4hJAgL1E8RaXNC071G4Kso2MGmJskCFQhRhg8VOH/FDbC8soP8NHN7e/Hdphwp8G8cE6OBzC8o41ZA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/types": "8.33.1",
-        "@typescript-eslint/visitor-keys": "8.33.1"
+        "@typescript-eslint/types": "8.34.1",
+        "@typescript-eslint/visitor-keys": "8.34.1"
       },
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -2778,9 +2795,9 @@
       }
     },
     "node_modules/@typescript-eslint/tsconfig-utils": {
-      "version": "8.33.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/tsconfig-utils/-/tsconfig-utils-8.33.1.tgz",
-      "integrity": "sha512-STAQsGYbHCF0/e+ShUQ4EatXQ7ceh3fBCXkNU7/MZVKulrlq1usH7t2FhxvCpuCi5O5oi1vmVaAjrGeL71OK1g==",
+      "version": "8.34.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/tsconfig-utils/-/tsconfig-utils-8.34.1.tgz",
+      "integrity": "sha512-K4Sjdo4/xF9NEeA2khOb7Y5nY6NSXBnod87uniVYW9kHP+hNlDV8trUSFeynA2uxWam4gIWgWoygPrv9VMWrYg==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -2795,14 +2812,14 @@
       }
     },
     "node_modules/@typescript-eslint/type-utils": {
-      "version": "8.33.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-8.33.1.tgz",
-      "integrity": "sha512-1cG37d9xOkhlykom55WVwG2QRNC7YXlxMaMzqw2uPeJixBFfKWZgaP/hjAObqMN/u3fr5BrTwTnc31/L9jQ2ww==",
+      "version": "8.34.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-8.34.1.tgz",
+      "integrity": "sha512-Tv7tCCr6e5m8hP4+xFugcrwTOucB8lshffJ6zf1mF1TbU67R+ntCc6DzLNKM+s/uzDyv8gLq7tufaAhIBYeV8g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/typescript-estree": "8.33.1",
-        "@typescript-eslint/utils": "8.33.1",
+        "@typescript-eslint/typescript-estree": "8.34.1",
+        "@typescript-eslint/utils": "8.34.1",
         "debug": "^4.3.4",
         "ts-api-utils": "^2.1.0"
       },
@@ -2819,16 +2836,16 @@
       }
     },
     "node_modules/@typescript-eslint/type-utils/node_modules/@typescript-eslint/typescript-estree": {
-      "version": "8.33.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-8.33.1.tgz",
-      "integrity": "sha512-+s9LYcT8LWjdYWu7IWs7FvUxpQ/DGkdjZeE/GGulHvv8rvYwQvVaUZ6DE+j5x/prADUgSbbCWZ2nPI3usuVeOA==",
+      "version": "8.34.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-8.34.1.tgz",
+      "integrity": "sha512-rjCNqqYPuMUF5ODD+hWBNmOitjBWghkGKJg6hiCHzUvXRy6rK22Jd3rwbP2Xi+R7oYVvIKhokHVhH41BxPV5mA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/project-service": "8.33.1",
-        "@typescript-eslint/tsconfig-utils": "8.33.1",
-        "@typescript-eslint/types": "8.33.1",
-        "@typescript-eslint/visitor-keys": "8.33.1",
+        "@typescript-eslint/project-service": "8.34.1",
+        "@typescript-eslint/tsconfig-utils": "8.34.1",
+        "@typescript-eslint/types": "8.34.1",
+        "@typescript-eslint/visitor-keys": "8.34.1",
         "debug": "^4.3.4",
         "fast-glob": "^3.3.2",
         "is-glob": "^4.0.3",
@@ -2848,16 +2865,16 @@
       }
     },
     "node_modules/@typescript-eslint/type-utils/node_modules/@typescript-eslint/utils": {
-      "version": "8.33.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-8.33.1.tgz",
-      "integrity": "sha512-52HaBiEQUaRYqAXpfzWSR2U3gxk92Kw006+xZpElaPMg3C4PgM+A5LqwoQI1f9E5aZ/qlxAZxzm42WX+vn92SQ==",
+      "version": "8.34.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-8.34.1.tgz",
+      "integrity": "sha512-mqOwUdZ3KjtGk7xJJnLbHxTuWVn3GO2WZZuM+Slhkun4+qthLdXx32C8xIXbO1kfCECb3jIs3eoxK3eryk7aoQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.7.0",
-        "@typescript-eslint/scope-manager": "8.33.1",
-        "@typescript-eslint/types": "8.33.1",
-        "@typescript-eslint/typescript-estree": "8.33.1"
+        "@typescript-eslint/scope-manager": "8.34.1",
+        "@typescript-eslint/types": "8.34.1",
+        "@typescript-eslint/typescript-estree": "8.34.1"
       },
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -2872,9 +2889,9 @@
       }
     },
     "node_modules/@typescript-eslint/types": {
-      "version": "8.33.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-8.33.1.tgz",
-      "integrity": "sha512-xid1WfizGhy/TKMTwhtVOgalHwPtV8T32MS9MaH50Cwvz6x6YqRIPdD2WvW0XaqOzTV9p5xdLY0h/ZusU5Lokg==",
+      "version": "8.34.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-8.34.1.tgz",
+      "integrity": "sha512-rjLVbmE7HR18kDsjNIZQHxmv9RZwlgzavryL5Lnj2ujIRTeXlKtILHgRNmQ3j4daw7zd+mQgy+uyt6Zo6I0IGA==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -3045,14 +3062,14 @@
       }
     },
     "node_modules/@typescript-eslint/visitor-keys": {
-      "version": "8.33.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-8.33.1.tgz",
-      "integrity": "sha512-3i8NrFcZeeDHJ+7ZUuDkGT+UHq+XoFGsymNK2jZCOHcfEzRQ0BdpRtdpSx/Iyf3MHLWIcLS0COuOPibKQboIiQ==",
+      "version": "8.34.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-8.34.1.tgz",
+      "integrity": "sha512-xoh5rJ+tgsRKoXnkBPFRLZ7rjKM0AfVbC68UZ/ECXoDbfggb9RbEySN359acY1vS3qZ0jVTVWzbtfapwm5ztxw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/types": "8.33.1",
-        "eslint-visitor-keys": "^4.2.0"
+        "@typescript-eslint/types": "8.34.1",
+        "eslint-visitor-keys": "^4.2.1"
       },
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -3063,9 +3080,9 @@
       }
     },
     "node_modules/@typescript-eslint/visitor-keys/node_modules/eslint-visitor-keys": {
-      "version": "4.2.0",
-      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-4.2.0.tgz",
-      "integrity": "sha512-UyLnSehNt62FFhSwjZlHmeokpRK59rcz29j+F1/aDgbkbRTk7wIc9XzdoasMUbRNKDM0qQt/+BJ4BrpFeABemw==",
+      "version": "4.2.1",
+      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-4.2.1.tgz",
+      "integrity": "sha512-Uhdk5sfqcee/9H/rCOJikYz67o0a2Tw2hGRPOG2Y1R2dg7brRe1uG0yaNQDHu+TO/uQPF/5eCapvYSmHUjt7JQ==",
       "dev": true,
       "license": "Apache-2.0",
       "engines": {
@@ -5587,9 +5604,9 @@
       }
     },
     "node_modules/openai": {
-      "version": "5.1.0",
-      "resolved": "https://registry.npmjs.org/openai/-/openai-5.1.0.tgz",
-      "integrity": "sha512-YQBgPJykHrDOlngB/8QpOsFNg36yofBatpeDWg1zejl9R59/ELuN7AMPSU95ZIdChbKc/o5vg1UnBJ1OEB0IJA==",
+      "version": "5.5.1",
+      "resolved": "https://registry.npmjs.org/openai/-/openai-5.5.1.tgz",
+      "integrity": "sha512-5i19097mGotHA1eFsM6Tjd/tJ8uo9sa5Ysv4Q6bKJ2vtN6rc0MzMrUefXnLXYAJcmMQrC1Efhj0AvfIkXrQamw==",
       "license": "Apache-2.0",
       "bin": {
         "openai": "bin/cli"
@@ -6880,9 +6897,9 @@
       }
     },
     "node_modules/vite-node": {
-      "version": "3.2.1",
-      "resolved": "https://registry.npmjs.org/vite-node/-/vite-node-3.2.1.tgz",
-      "integrity": "sha512-V4EyKQPxquurNJPtQJRZo8hKOoKNBRIhxcDbQFPFig0JdoWcUhwRgK8yoCXXrfYVPKS6XwirGHPszLnR8FbjCA==",
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/vite-node/-/vite-node-3.2.4.tgz",
+      "integrity": "sha512-EbKSKh+bh1E1IFxeO0pg1n4dvoOTt0UDiXMd/qn++r98+jPO1xtJilvXldeuQ8giIB5IkpjCgMleHMNEsGH6pg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -26,7 +26,8 @@
         "prettier": "3.5.3",
         "rimraf": "6.0.1",
         "typescript": "5.8.3",
-        "vite-node": "^3.2.4"
+        "vite-node": "^3.2.4",
+        "vitest": "^3.2.4"
       }
     },
     "node_modules/@anthropic-ai/sdk": {
@@ -1342,6 +1343,13 @@
         "url": "https://github.com/chalk/strip-ansi?sponsor=1"
       }
     },
+    "node_modules/@jridgewell/sourcemap-codec": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.0.tgz",
+      "integrity": "sha512-gv3ZRaISU3fjPAgNsriBRqGWQL6quFx04YMPW/zD8XMLsU32mhCCbfbO6KZFLjvYpCZ8zyDEgqsgf+PwPaM7GQ==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@mfbtech/llm-api-types": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/@mfbtech/llm-api-types/-/llm-api-types-1.0.0.tgz",
@@ -2577,6 +2585,23 @@
         "node": ">=18.0.0"
       }
     },
+    "node_modules/@types/chai": {
+      "version": "5.2.2",
+      "resolved": "https://registry.npmjs.org/@types/chai/-/chai-5.2.2.tgz",
+      "integrity": "sha512-8kB30R7Hwqf40JPiKhVzodJs2Qc1ZJ5zuT3uzw5Hq/dhNCl3G3l83jfpdI1e20BP348+fV7VIL/+FxaXkqBmWg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/deep-eql": "*"
+      }
+    },
+    "node_modules/@types/deep-eql": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/@types/deep-eql/-/deep-eql-4.0.2.tgz",
+      "integrity": "sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@types/estree": {
       "version": "1.0.6",
       "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.6.tgz",
@@ -3099,6 +3124,121 @@
       "dev": true,
       "license": "ISC"
     },
+    "node_modules/@vitest/expect": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-3.2.4.tgz",
+      "integrity": "sha512-Io0yyORnB6sikFlt8QW5K7slY4OjqNX9jmJQ02QDda8lyM6B5oNgVWoSoKPac8/kgnCUzuHQKrSLtu/uOqqrig==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/chai": "^5.2.2",
+        "@vitest/spy": "3.2.4",
+        "@vitest/utils": "3.2.4",
+        "chai": "^5.2.0",
+        "tinyrainbow": "^2.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/mocker": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-3.2.4.tgz",
+      "integrity": "sha512-46ryTE9RZO/rfDd7pEqFl7etuyzekzEhUbTW3BvmeO/BcCMEgq59BKhek3dXDWgAj4oMK6OZi+vRr1wPW6qjEQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/spy": "3.2.4",
+        "estree-walker": "^3.0.3",
+        "magic-string": "^0.30.17"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "msw": "^2.4.9",
+        "vite": "^5.0.0 || ^6.0.0 || ^7.0.0-0"
+      },
+      "peerDependenciesMeta": {
+        "msw": {
+          "optional": true
+        },
+        "vite": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@vitest/pretty-format": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-3.2.4.tgz",
+      "integrity": "sha512-IVNZik8IVRJRTr9fxlitMKeJeXFFFN0JaB9PHPGQ8NKQbGpfjlTx9zO4RefN8gp7eqjNy8nyK3NZmBzOPeIxtA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tinyrainbow": "^2.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/runner": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-3.2.4.tgz",
+      "integrity": "sha512-oukfKT9Mk41LreEW09vt45f8wx7DordoWUZMYdY/cyAk7w5TWkTRCNZYF7sX7n2wB7jyGAl74OxgwhPgKaqDMQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/utils": "3.2.4",
+        "pathe": "^2.0.3",
+        "strip-literal": "^3.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/snapshot": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-3.2.4.tgz",
+      "integrity": "sha512-dEYtS7qQP2CjU27QBC5oUOxLE/v5eLkGqPE0ZKEIDGMs4vKWe7IjgLOeauHsR0D5YuuycGRO5oSRXnwnmA78fQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "3.2.4",
+        "magic-string": "^0.30.17",
+        "pathe": "^2.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/spy": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-3.2.4.tgz",
+      "integrity": "sha512-vAfasCOe6AIK70iP5UD11Ac4siNUNJ9i/9PZ3NKx07sG6sUxeag1LWdNrMWeKKYBLlzuK+Gn65Yd5nyL6ds+nw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tinyspy": "^4.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/utils": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-3.2.4.tgz",
+      "integrity": "sha512-fB2V0JFrQSMsCo9HiSq3Ezpdv4iYaXRG1Sx8edX3MwxfyNn83mKiGzOcH+Fkxt4MHxr3y42fQi1oeAInqgX2QA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "3.2.4",
+        "loupe": "^3.1.4",
+        "tinyrainbow": "^2.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
     "node_modules/acorn": {
       "version": "8.14.1",
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.14.1.tgz",
@@ -3287,6 +3427,16 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/assertion-error": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-2.0.1.tgz",
+      "integrity": "sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      }
+    },
     "node_modules/async-function": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/async-function/-/async-function-1.0.0.tgz",
@@ -3419,6 +3569,23 @@
         "node": ">=6"
       }
     },
+    "node_modules/chai": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/chai/-/chai-5.2.0.tgz",
+      "integrity": "sha512-mCuXncKXk5iCLhfhwTc0izo0gtEmpz5CtG2y8GiOINBlMVS6v8TMRc5TaLWKS6692m9+dVVfzgeVxR5UxWHTYw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "assertion-error": "^2.0.1",
+        "check-error": "^2.1.1",
+        "deep-eql": "^5.0.1",
+        "loupe": "^3.1.0",
+        "pathval": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
     "node_modules/chalk": {
       "version": "4.1.2",
       "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
@@ -3434,6 +3601,16 @@
       },
       "funding": {
         "url": "https://github.com/chalk/chalk?sponsor=1"
+      }
+    },
+    "node_modules/check-error": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/check-error/-/check-error-2.1.1.tgz",
+      "integrity": "sha512-OAlb+T7V4Op9OwdkjmguYRqncdlx5JiofwOAUkmTF+jNdHwzTaTs4sRAGpzLF3oOz5xAyDGrPgeIDFQmDOTiJw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 16"
       }
     },
     "node_modules/color-convert": {
@@ -3548,6 +3725,16 @@
         "supports-color": {
           "optional": true
         }
+      }
+    },
+    "node_modules/deep-eql": {
+      "version": "5.0.2",
+      "resolved": "https://registry.npmjs.org/deep-eql/-/deep-eql-5.0.2.tgz",
+      "integrity": "sha512-h5k/5U50IJJFpzfL6nO9jaaumfjO/f2NjK/oYB2Djzm4p9L+3T9qWpZqZ2hAbLPuuYq9wrU08WQyBTL5GbPk5Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
       }
     },
     "node_modules/deep-is": {
@@ -4150,6 +4337,16 @@
         "node": ">=4.0"
       }
     },
+    "node_modules/estree-walker": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-3.0.3.tgz",
+      "integrity": "sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "^1.0.0"
+      }
+    },
     "node_modules/esutils": {
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.3.tgz",
@@ -4158,6 +4355,16 @@
       "license": "BSD-2-Clause",
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/expect-type": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/expect-type/-/expect-type-1.2.1.tgz",
+      "integrity": "sha512-/kP8CAwxzLVEeFrMm4kMmy4CCDlpipyA7MYLVrdJIkV0fYF0UaigQHRsxHiuY/GEea+bh4KSv3TIlgr+2UL6bw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=12.0.0"
       }
     },
     "node_modules/fast-deep-equal": {
@@ -5365,6 +5572,13 @@
         "loose-envify": "cli.js"
       }
     },
+    "node_modules/loupe": {
+      "version": "3.1.4",
+      "resolved": "https://registry.npmjs.org/loupe/-/loupe-3.1.4.tgz",
+      "integrity": "sha512-wJzkKwJrheKtknCOKNEtDK4iqg/MxmZheEMtSTYvnzRdEYaZzmgH976nenp8WdJRdx5Vc1X/9MO0Oszl6ezeXg==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/lru-cache": {
       "version": "11.0.2",
       "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.0.2.tgz",
@@ -5373,6 +5587,16 @@
       "license": "ISC",
       "engines": {
         "node": "20 || >=22"
+      }
+    },
+    "node_modules/magic-string": {
+      "version": "0.30.17",
+      "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.17.tgz",
+      "integrity": "sha512-sNPKHvyjVf7gyjwS4xGTaW/mCnF8wnjtifKBEhxfZ7E/S8tQ0rssrwGNn6q8JH/ohItJfSQp9mBtQYuTlH5QnA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/sourcemap-codec": "^1.5.0"
       }
     },
     "node_modules/math-intrinsics": {
@@ -5772,6 +5996,16 @@
       "integrity": "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/pathval": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/pathval/-/pathval-2.0.0.tgz",
+      "integrity": "sha512-vE7JKRyES09KiunauX7nd2Q9/L7lhok4smP9RZTDeD4MVs72Dp2qNFVz39Nz5a0FVEW0BJR6C0DYrq6unoziZA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 14.16"
+      }
     },
     "node_modules/picocolors": {
       "version": "1.1.1",
@@ -6319,6 +6553,13 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/siginfo": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/siginfo/-/siginfo-2.0.0.tgz",
+      "integrity": "sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==",
+      "dev": true,
+      "license": "ISC"
+    },
     "node_modules/signal-exit": {
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-4.1.0.tgz",
@@ -6341,6 +6582,20 @@
       "engines": {
         "node": ">=0.10.0"
       }
+    },
+    "node_modules/stackback": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/stackback/-/stackback-0.0.2.tgz",
+      "integrity": "sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/std-env": {
+      "version": "3.9.0",
+      "resolved": "https://registry.npmjs.org/std-env/-/std-env-3.9.0.tgz",
+      "integrity": "sha512-UGvjygr6F6tpH7o2qyqR6QYpwraIjKSdtzyBdyytFOHmPZY917kwdwLG0RbOjWOnKmnm3PeHjaoLLMie7kPLQw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/string-width": {
       "version": "5.1.2",
@@ -6539,6 +6794,26 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/strip-literal": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/strip-literal/-/strip-literal-3.0.0.tgz",
+      "integrity": "sha512-TcccoMhJOM3OebGhSBEmp3UZ2SfDMZUEBdRA/9ynfLi8yYajyWX3JiXArcJt4Umh4vISpspkQIY8ZZoCqjbviA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "js-tokens": "^9.0.1"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/antfu"
+      }
+    },
+    "node_modules/strip-literal/node_modules/js-tokens": {
+      "version": "9.0.1",
+      "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-9.0.1.tgz",
+      "integrity": "sha512-mxa9E9ITFOt0ban3j6L5MpjwegGz6lBQmM1IJkWeBZGcMxto50+eWdjC/52xDbS2vy0k7vIMK0Fe2wfL9OQSpQ==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/strnum": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/strnum/-/strnum-1.1.2.tgz",
@@ -6584,10 +6859,24 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/tinybench": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/tinybench/-/tinybench-2.9.0.tgz",
+      "integrity": "sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/tinyexec": {
+      "version": "0.3.2",
+      "resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-0.3.2.tgz",
+      "integrity": "sha512-KQQR9yN7R5+OSwaK0XQoj22pwHoTlgYqmUscPYoknOoWCWfj/5/ABTMRi69FrKU5ffPVh5QcFikpWJI/P1ocHA==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/tinyglobby": {
-      "version": "0.2.13",
-      "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.13.tgz",
-      "integrity": "sha512-mEwzpUgrLySlveBwEVDMKk5B57bhLPYovRfPAXD5gA/98Opn0rCDj3GtLwFvCvH5RK9uPCExUROW5NjDwvqkxw==",
+      "version": "0.2.14",
+      "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.14.tgz",
+      "integrity": "sha512-tX5e7OM1HnYr2+a2C/4V0htOcSQcoSTH9KgJnVvNm5zm/cyEWKJ7j7YutsH9CxMdtOkkLFy2AHrMci9IM8IPZQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -6627,6 +6916,36 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/tinypool": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/tinypool/-/tinypool-1.1.1.tgz",
+      "integrity": "sha512-Zba82s87IFq9A9XmjiX5uZA/ARWDrB03OHlq+Vw1fSdt0I+4/Kutwy8BP4Y/y/aORMo61FQ0vIb5j44vSo5Pkg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^18.0.0 || >=20.0.0"
+      }
+    },
+    "node_modules/tinyrainbow": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/tinyrainbow/-/tinyrainbow-2.0.0.tgz",
+      "integrity": "sha512-op4nsTR47R6p0vMUUoYl/a+ljLFVtlfaXkLQmqfLR1qHma1h/ysYk4hEXZ880bf2CYgTskvTa/e196Vd5dDQXw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/tinyspy": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/tinyspy/-/tinyspy-4.0.3.tgz",
+      "integrity": "sha512-t2T/WLB2WRgZ9EpE4jgPJ9w+i66UZfDc8wHh0xrwiRNN+UwH98GIJkTeZqX9rg0i0ptwzqW+uYeIF0T4F8LR7A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
       }
     },
     "node_modules/to-regex-range": {
@@ -6947,6 +7266,92 @@
         "url": "https://github.com/sponsors/jonschlinkert"
       }
     },
+    "node_modules/vitest": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/vitest/-/vitest-3.2.4.tgz",
+      "integrity": "sha512-LUCP5ev3GURDysTWiP47wRRUpLKMOfPh+yKTx3kVIEiu5KOMeqzpnYNsKyOoVrULivR8tLcks4+lga33Whn90A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/chai": "^5.2.2",
+        "@vitest/expect": "3.2.4",
+        "@vitest/mocker": "3.2.4",
+        "@vitest/pretty-format": "^3.2.4",
+        "@vitest/runner": "3.2.4",
+        "@vitest/snapshot": "3.2.4",
+        "@vitest/spy": "3.2.4",
+        "@vitest/utils": "3.2.4",
+        "chai": "^5.2.0",
+        "debug": "^4.4.1",
+        "expect-type": "^1.2.1",
+        "magic-string": "^0.30.17",
+        "pathe": "^2.0.3",
+        "picomatch": "^4.0.2",
+        "std-env": "^3.9.0",
+        "tinybench": "^2.9.0",
+        "tinyexec": "^0.3.2",
+        "tinyglobby": "^0.2.14",
+        "tinypool": "^1.1.1",
+        "tinyrainbow": "^2.0.0",
+        "vite": "^5.0.0 || ^6.0.0 || ^7.0.0-0",
+        "vite-node": "3.2.4",
+        "why-is-node-running": "^2.3.0"
+      },
+      "bin": {
+        "vitest": "vitest.mjs"
+      },
+      "engines": {
+        "node": "^18.0.0 || ^20.0.0 || >=22.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "@edge-runtime/vm": "*",
+        "@types/debug": "^4.1.12",
+        "@types/node": "^18.0.0 || ^20.0.0 || >=22.0.0",
+        "@vitest/browser": "3.2.4",
+        "@vitest/ui": "3.2.4",
+        "happy-dom": "*",
+        "jsdom": "*"
+      },
+      "peerDependenciesMeta": {
+        "@edge-runtime/vm": {
+          "optional": true
+        },
+        "@types/debug": {
+          "optional": true
+        },
+        "@types/node": {
+          "optional": true
+        },
+        "@vitest/browser": {
+          "optional": true
+        },
+        "@vitest/ui": {
+          "optional": true
+        },
+        "happy-dom": {
+          "optional": true
+        },
+        "jsdom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/vitest/node_modules/picomatch": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.2.tgz",
+      "integrity": "sha512-M7BAV6Rlcy5u+m6oPhAPFgJTzAioX/6B0DxyvDlo9l8+T3nLKbrczg2WLUyzd45L8RqfUMyGPzekbMvX2Ldkwg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
     "node_modules/which": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
@@ -7050,6 +7455,23 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/why-is-node-running": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/why-is-node-running/-/why-is-node-running-2.3.0.tgz",
+      "integrity": "sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "siginfo": "^2.0.0",
+        "stackback": "0.0.2"
+      },
+      "bin": {
+        "why-is-node-running": "cli.js"
+      },
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/word-wrap": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mfbtech/llm-popular",
-  "version": "1.4.0",
+  "version": "1.4.1",
   "description": "Create uniform bindings for popular llm apis",
   "main": "lib/index.js",
   "types": "lib/index.d.ts",

--- a/package.json
+++ b/package.json
@@ -16,21 +16,21 @@
   "devDependencies": {
     "@mfbtech/llm-api-types": "1.0.0",
     "@rushstack/eslint-config": "4.3.0",
-    "@types/node": "^22.15.29",
-    "@typescript-eslint/eslint-plugin": "^8.33.1",
-    "@typescript-eslint/parser": "^8.33.1",
+    "@types/node": "^22.15.32",
+    "@typescript-eslint/eslint-plugin": "^8.34.1",
+    "@typescript-eslint/parser": "^8.34.1",
     "dotenv": "16.5.0",
     "eslint": "^8.57.1",
     "prettier": "3.5.3",
     "rimraf": "6.0.1",
     "typescript": "5.8.3",
-    "vite-node": "^3.2.1"
+    "vite-node": "^3.2.4"
   },
   "dependencies": {
-    "@anthropic-ai/sdk": "^0.52.0",
-    "@aws-sdk/client-bedrock-runtime": "^3.821.0",
+    "@anthropic-ai/sdk": "^0.54.0",
+    "@aws-sdk/client-bedrock-runtime": "^3.830.0",
     "@google/generative-ai": "^0.24.1",
     "nanoid": "5.1.5",
-    "openai": "^5.1.0"
+    "openai": "^5.5.1"
   }
 }

--- a/package.json
+++ b/package.json
@@ -10,7 +10,8 @@
     "lint": "eslint ./src/",
     "fix-formatting": "prettier --write --config prettier.config.cjs ./src/",
     "check-formatting": "prettier --check --config prettier.config.cjs ./src/",
-    "test": "vitest"
+    "test": "vitest run",
+    "test:watch": "vitest"
   },
   "author": "MFB Technologies, Inc.",
   "license": "MIT",

--- a/package.json
+++ b/package.json
@@ -9,7 +9,8 @@
     "build": "rimraf ./lib && tsc --project tsconfig.prod.json",
     "lint": "eslint ./src/",
     "fix-formatting": "prettier --write --config prettier.config.cjs ./src/",
-    "check-formatting": "prettier --check --config prettier.config.cjs ./src/"
+    "check-formatting": "prettier --check --config prettier.config.cjs ./src/",
+    "test": "vitest"
   },
   "author": "MFB Technologies, Inc.",
   "license": "MIT",
@@ -24,7 +25,8 @@
     "prettier": "3.5.3",
     "rimraf": "6.0.1",
     "typescript": "5.8.3",
-    "vite-node": "^3.2.4"
+    "vite-node": "^3.2.4",
+    "vitest": "^3.2.4"
   },
   "dependencies": {
     "@anthropic-ai/sdk": "^0.54.0",

--- a/src/aws-llama/convertToLlamaPrompt.test.ts
+++ b/src/aws-llama/convertToLlamaPrompt.test.ts
@@ -1,0 +1,133 @@
+import { describe, it, expect } from "vitest"
+import { convertToLlamaPrompt } from "./convertToLlamaPrompt.js"
+
+describe("convertToLlamaPrompt", () => {
+  describe("Llama 3 format (default)", () => {
+    it("should convert a simple user message to Llama 3 prompt format", () => {
+      const input = [{ role: "user" as const, text: "Hello, how are you?" }]
+      const result = convertToLlamaPrompt(input)
+
+      expect(result.prompt).toBe(
+        "<|begin_of_text|><|start_header_id|>user<|end_header_id|>Hello, how are you?<|eot_id|><|start_header_id|>assistant<|end_header_id|>\n"
+      )
+      expect(result.max_gen_len).toBe(2048)
+      expect(result.temperature).toBe(0.5)
+      expect(result.top_p).toBe(0.9)
+    })
+
+    it("should handle multiple messages in conversation", () => {
+      const input = [
+        { role: "user" as const, text: "What's 2+2?" },
+        { role: "assistant" as const, text: "2+2 equals 4." },
+        { role: "user" as const, text: "What about 3+3?" }
+      ]
+      const result = convertToLlamaPrompt(input)
+
+      expect(result.prompt).toBe(
+        "<|begin_of_text|><|start_header_id|>user<|end_header_id|>What's 2+2?<|eot_id|><|start_header_id|>assistant<|end_header_id|>2+2 equals 4.<|eot_id|><|start_header_id|>user<|end_header_id|>What about 3+3?<|eot_id|><|start_header_id|>assistant<|end_header_id|>\n"
+      )
+    })
+
+    it("should include system instructions when provided", () => {
+      const input = [{ role: "user" as const, text: "Tell me a joke" }]
+      const instructions = "You are a helpful assistant who tells funny jokes."
+      const result = convertToLlamaPrompt(input, instructions)
+
+      expect(result.prompt).toBe(
+        "<|begin_of_text|><|start_header_id|>system<|end_header_id|>You are a helpful assistant who tells funny jokes.<|eot_id|><|start_header_id|>user<|end_header_id|>Tell me a joke<|eot_id|><|start_header_id|>assistant<|end_header_id|>\n"
+      )
+    })
+
+    it("should handle empty input array", () => {
+      const input: { role: "user" | "assistant"; text: string }[] = []
+      const result = convertToLlamaPrompt(input)
+
+      expect(result.prompt).toBe(
+        "<|begin_of_text|><|start_header_id|>assistant<|end_header_id|>\n"
+      )
+    })
+  })
+
+  describe("Llama 4 format", () => {
+    it("should convert a simple user message to Llama 4 prompt format", () => {
+      const input = [{ role: "user" as const, text: "Hello, how are you?" }]
+      const result = convertToLlamaPrompt(input, undefined, "4")
+
+      expect(result.prompt).toBe(
+        "<|begin_of_text|><|header_start|>user<|header_end|>\n\nHello, how are you?<|eot|><|header_start|>assistant<|header_end|>\n"
+      )
+    })
+
+    it("should handle multiple messages in conversation with Llama 4 format", () => {
+      const input = [
+        { role: "user" as const, text: "What's 2+2?" },
+        { role: "assistant" as const, text: "2+2 equals 4." },
+        { role: "user" as const, text: "What about 3+3?" }
+      ]
+      const result = convertToLlamaPrompt(input, undefined, "4")
+
+      expect(result.prompt).toBe(
+        "<|begin_of_text|><|header_start|>user<|header_end|>\n\nWhat's 2+2?<|eot|><|header_start|>assistant<|header_end|>\n\n2+2 equals 4.<|eot|><|header_start|>user<|header_end|>\n\nWhat about 3+3?<|eot|><|header_start|>assistant<|header_end|>\n"
+      )
+    })
+
+    it("should include system instructions with Llama 4 format", () => {
+      const input = [{ role: "user" as const, text: "Tell me a joke" }]
+      const instructions = "You are a helpful assistant who tells funny jokes."
+      const result = convertToLlamaPrompt(input, instructions, "4")
+
+      expect(result.prompt).toBe(
+        "<|begin_of_text|><|header_start|>system<|header_end|>\n\nYou are a helpful assistant who tells funny jokes.<|eot|><|header_start|>user<|header_end|>\n\nTell me a joke<|eot|><|header_start|>assistant<|header_end|>\n"
+      )
+    })
+
+    it("should handle empty input array with Llama 4 format", () => {
+      const input: { role: "user" | "assistant"; text: string }[] = []
+      const result = convertToLlamaPrompt(input, undefined, "4")
+
+      expect(result.prompt).toBe(
+        "<|begin_of_text|><|header_start|>assistant<|header_end|>\n"
+      )
+    })
+
+    it("should handle multi-line messages in Llama 4 format", () => {
+      const input = [
+        {
+          role: "user" as const,
+          text: "Line 1\nLine 2\nLine 3"
+        }
+      ]
+      const result = convertToLlamaPrompt(input, undefined, "4")
+
+      expect(result.prompt).toBe(
+        "<|begin_of_text|><|header_start|>user<|header_end|>\n\nLine 1\nLine 2\nLine 3<|eot|><|header_start|>assistant<|header_end|>\n"
+      )
+    })
+  })
+
+  describe("Common behavior", () => {
+    it("should handle special characters in messages", () => {
+      const input = [
+        {
+          role: "user" as const,
+          text: "Can you explain <|start_header_id|> and <|eot_id|>?"
+        }
+      ]
+      const result = convertToLlamaPrompt(input)
+
+      expect(result.prompt).toBe(
+        "<|begin_of_text|><|start_header_id|>user<|end_header_id|>Can you explain <|start_header_id|> and <|eot_id|>?<|eot_id|><|start_header_id|>assistant<|end_header_id|>\n"
+      )
+    })
+
+    it("should return consistent default parameters", () => {
+      const input = [{ role: "user" as const, text: "Test" }]
+      const result = convertToLlamaPrompt(input)
+
+      expect(result).toHaveProperty("prompt")
+      expect(result).toHaveProperty("max_gen_len", 2048)
+      expect(result).toHaveProperty("temperature", 0.5)
+      expect(result).toHaveProperty("top_p", 0.9)
+    })
+  })
+})

--- a/src/aws-llama/convertToLlamaPrompt.ts
+++ b/src/aws-llama/convertToLlamaPrompt.ts
@@ -1,0 +1,62 @@
+export type Llama33 = {
+  prompt: string
+  /** @property {number} [max_gen_len=512] - The maximum number of tokens for the generated response.
+   * The response is truncated once it exceeds this value.
+   * Defaults to `512`. Minimum: `1`, Maximum: `2048`.
+   */
+  max_gen_len?: number
+  /**
+   * Controls the randomness of the response.
+   * A lower value decreases randomness.
+   * Defaults to `0.5`. Minimum: `0`, Maximum: `1`.
+   */
+  temperature?: number
+  /**
+   * Filters out less probable options.
+   * Use `0` or `1.0` to disable.
+   * Defaults to `0.9`. Minimum: `0`, Maximum: `1`.
+   */
+  top_p?: number
+}
+
+export function convertToLlamaPrompt(
+  input: { role: "user" | "assistant"; text: string }[],
+  instructions?: string,
+  version: "3" | "4" = "3"
+): Llama33 {
+  let llamaPrompt = `<|begin_of_text|>`
+
+  if (version === "4") {
+    // Llama 4 format
+    if (instructions) {
+      llamaPrompt += `<|header_start|>system<|header_end|>\n\n${instructions}<|eot|>`
+    }
+
+    for (const message of input) {
+      llamaPrompt += `<|header_start|>${message.role}<|header_end|>\n\n${message.text}<|eot|>`
+    }
+
+    // End the prompt for Llama 4
+    llamaPrompt += "<|header_start|>assistant<|header_end|>\n"
+  } else {
+    // Llama 3 format (default)
+    if (instructions) {
+      llamaPrompt += `<|start_header_id|>system<|end_header_id|>${instructions}<|eot_id|>`
+    }
+
+    for (const message of input) {
+      llamaPrompt += `<|start_header_id|>${message.role}<|end_header_id|>${message.text}<|eot_id|>`
+    }
+
+    // End the prompt for Llama 3
+    llamaPrompt += "<|start_header_id|>assistant<|end_header_id|>\n"
+  }
+
+  // Return the final prompt string
+  return {
+    prompt: llamaPrompt,
+    max_gen_len: 2048,
+    temperature: 0.5,
+    top_p: 0.9
+  }
+}

--- a/src/aws-llama/convertToLlamaPrompt.ts
+++ b/src/aws-llama/convertToLlamaPrompt.ts
@@ -1,4 +1,4 @@
-export type Llama33 = {
+export type LlamaPrompt = {
   prompt: string
   /** @property {number} [max_gen_len=512] - The maximum number of tokens for the generated response.
    * The response is truncated once it exceeds this value.
@@ -23,7 +23,7 @@ export function convertToLlamaPrompt(
   input: { role: "user" | "assistant"; text: string }[],
   instructions?: string,
   version: "3" | "4" = "3"
-): Llama33 {
+): LlamaPrompt {
   let llamaPrompt = `<|begin_of_text|>`
 
   if (version === "4") {

--- a/src/aws-llama/index.ts
+++ b/src/aws-llama/index.ts
@@ -5,11 +5,11 @@ import {
 } from "@aws-sdk/client-bedrock-runtime"
 import { ChatPrompt, ModelApi } from "@mfbtech/llm-api-types"
 import { convertToLlamaPrompt } from "./convertToLlamaPrompt.js"
-type MetaNewModel =
-  | "us.meta.llama3-3-70b-instruct-v1:0"
+type Meta4Model =
   | "us.meta.llama4-maverick-17b-instruct-v1:0"
   | "us.meta.llama4-scout-17b-instruct-v1:0"
-type Meta32Model =
+type Meta3Model =
+  | "us.meta.llama3-3-70b-instruct-v1:0"
   | "us.meta.llama3-2-1b-instruct-v1:0"
   | "us.meta.llama3-2-3b-instruct-v1:0"
 
@@ -52,7 +52,7 @@ export type TextCompletionResponse = {
 }
 
 export function buildLlamaLlm(
-  model: MetaNewModel | Meta32Model,
+  model: Meta4Model | Meta3Model,
   awsCredentials: {
     awsAccessKey: string
     awsSecret: string

--- a/src/aws-llama/index.ts
+++ b/src/aws-llama/index.ts
@@ -4,6 +4,7 @@ import {
   InvokeModelWithResponseStreamCommand
 } from "@aws-sdk/client-bedrock-runtime"
 import { ChatPrompt, ModelApi } from "@mfbtech/llm-api-types"
+import { convertToLlamaPrompt } from "./convertToLlamaPrompt.js"
 type MetaNewModel =
   | "us.meta.llama3-3-70b-instruct-v1:0"
   | "us.meta.llama4-maverick-17b-instruct-v1:0"
@@ -11,27 +12,6 @@ type MetaNewModel =
 type Meta32Model =
   | "us.meta.llama3-2-1b-instruct-v1:0"
   | "us.meta.llama3-2-3b-instruct-v1:0"
-
-type Llama33 = {
-  prompt: string
-  /** @property {number} [max_gen_len=512] - The maximum number of tokens for the generated response.
-   * The response is truncated once it exceeds this value.
-   * Defaults to `512`. Minimum: `1`, Maximum: `2048`.
-   */
-  max_gen_len?: number
-  /**
-   * Controls the randomness of the response.
-   * A lower value decreases randomness.
-   * Defaults to `0.5`. Minimum: `0`, Maximum: `1`.
-   */
-  temperature?: number
-  /**
-   * Filters out less probable options.
-   * Use `0` or `1.0` to disable.
-   * Defaults to `0.9`. Minimum: `0`, Maximum: `1`.
-   */
-  top_p?: number
-}
 
 /**
  * The response returned by Llama 2 Chat, Llama 2, and Llama 3 Instruct models
@@ -71,33 +51,6 @@ export type TextCompletionResponse = {
   }
 }
 
-function convertToLlamaPrompt(
-  input: { role: "user" | "assistant"; text: string }[],
-  instructions?: string
-): Llama33 {
-  let llamaPrompt = `<|begin_of_text|>`
-
-  if (instructions) {
-    llamaPrompt += `<|start_header_id|>system<|end_header_id|>${instructions}<|eot_id|>`
-  }
-
-  for (const message of input) {
-    llamaPrompt += `<|start_header_id|>${message.role}<|end_header_id|>${message.text}<|eot_id|>`
-  }
-
-  // End the prompt -- ending the prompt this way ensure the next thing it generates in it's
-  // completion is the start of the answer. Otherwise it will generate headers or newlines.
-  llamaPrompt += "<|start_header_id|>assistant<|end_header_id|>\n"
-
-  // Return the final prompt string
-  return {
-    prompt: llamaPrompt,
-    max_gen_len: 2048,
-    temperature: 0.5,
-    top_p: 0.9
-  }
-}
-
 export function buildLlamaLlm(
   model: MetaNewModel | Meta32Model,
   awsCredentials: {
@@ -126,10 +79,8 @@ export function buildLlamaLlm(
                 instructions
               )
             : convertToLlamaPrompt(
-                prompt.map(
-                  p => ({ role: p.role, text: p.prompt }),
-                  instructions
-                )
+                prompt.map(p => ({ role: p.role, text: p.prompt })),
+                instructions
               )
         )
       })
@@ -172,10 +123,8 @@ export function buildLlamaLlm(
                 instructions
               )
             : convertToLlamaPrompt(
-                prompt.map(
-                  p => ({ role: p.role, text: p.prompt }),
-                  instructions
-                )
+                prompt.map(p => ({ role: p.role, text: p.prompt })),
+                instructions
               )
         )
       })

--- a/src/aws-llama/index.ts
+++ b/src/aws-llama/index.ts
@@ -5,13 +5,22 @@ import {
 } from "@aws-sdk/client-bedrock-runtime"
 import { ChatPrompt, ModelApi } from "@mfbtech/llm-api-types"
 import { convertToLlamaPrompt } from "./convertToLlamaPrompt.js"
-type Meta4Model =
-  | "us.meta.llama4-maverick-17b-instruct-v1:0"
-  | "us.meta.llama4-scout-17b-instruct-v1:0"
-type Meta3Model =
-  | "us.meta.llama3-3-70b-instruct-v1:0"
-  | "us.meta.llama3-2-1b-instruct-v1:0"
-  | "us.meta.llama3-2-3b-instruct-v1:0"
+
+// Model constants
+const LLAMA_4_MODELS = [
+  "us.meta.llama4-maverick-17b-instruct-v1:0",
+  "us.meta.llama4-scout-17b-instruct-v1:0"
+] as const
+
+const LLAMA_3_MODELS = [
+  "us.meta.llama3-3-70b-instruct-v1:0",
+  "us.meta.llama3-2-1b-instruct-v1:0",
+  "us.meta.llama3-2-3b-instruct-v1:0"
+] as const
+
+// Infer types from constants
+type Meta4Model = (typeof LLAMA_4_MODELS)[number]
+type Meta3Model = (typeof LLAMA_3_MODELS)[number]
 
 /**
  * The response returned by Llama 2 Chat, Llama 2, and Llama 3 Instruct models
@@ -51,6 +60,17 @@ export type TextCompletionResponse = {
   }
 }
 
+// Helper function to determine Llama version from model name
+function getLlamaVersion(model: Meta4Model | Meta3Model): "3" | "4" {
+  if ((LLAMA_4_MODELS as readonly string[]).includes(model)) {
+    return "4"
+  } else if ((LLAMA_3_MODELS as readonly string[]).includes(model)) {
+    return "3"
+  }
+  // This should never happen due to TypeScript, but throw error for safety
+  throw new Error(`Unknown model: ${model}`)
+}
+
 export function buildLlamaLlm(
   model: Meta4Model | Meta3Model,
   awsCredentials: {
@@ -67,6 +87,9 @@ export function buildLlamaLlm(
     }
   })
 
+  // Determine the Llama version based on the model
+  const llamaVersion = getLlamaVersion(model)
+
   return {
     getText: async (prompt: string | ChatPrompt, instructions?: string) => {
       const invoke = new InvokeModelCommand({
@@ -76,11 +99,13 @@ export function buildLlamaLlm(
           typeof prompt === "string"
             ? convertToLlamaPrompt(
                 [{ role: "user", text: prompt }],
-                instructions
+                instructions,
+                llamaVersion
               )
             : convertToLlamaPrompt(
                 prompt.map(p => ({ role: p.role, text: p.prompt })),
-                instructions
+                instructions,
+                llamaVersion
               )
         )
       })
@@ -120,11 +145,13 @@ export function buildLlamaLlm(
           typeof prompt === "string"
             ? convertToLlamaPrompt(
                 [{ role: "user", text: prompt }],
-                instructions
+                instructions,
+                llamaVersion
               )
             : convertToLlamaPrompt(
                 prompt.map(p => ({ role: p.role, text: p.prompt })),
-                instructions
+                instructions,
+                llamaVersion
               )
         )
       })

--- a/src/gemini/index.ts
+++ b/src/gemini/index.ts
@@ -6,9 +6,9 @@ import { ModelApi, ChatPrompt } from "@mfbtech/llm-api-types"
 import { nanoid } from "nanoid"
 
 type GeminiModel =
-  | "gemini-2.5-pro-preview-05-06"
-  | "gemini-2.5-flash-preview-05-20"
-  | "gemini-2.0-flash"
+  | "gemini-2.5-pro"
+  | "gemini-2.5-flash"
+  | "gemini-2.5-flash-lite-preview-06-17"
 
 export function buildGeminiLlm(
   model: GeminiModel,


### PR DESCRIPTION
## Summary

This PR includes several improvements and updates:

### New Features
- **Llama 4 Support**: Added automatic version detection and support for Llama 4 models
  - Refactored `convertToLlamaPrompt` to a separate module with version-specific handling
  - Added comprehensive tests for Llama prompt conversion
  - Added new example demonstrating Llama 4 multiple message handling

### Model Updates
- **Gemini Models**: Updated to latest model names
  - `gemini-2.5-pro-preview-05-06` → `gemini-2.5-pro`
  - `gemini-2.5-flash-preview-05-20` → `gemini-2.5-flash`
  - Added `gemini-2.5-flash-lite-preview-06-17`

### Dependency Updates
- `@anthropic-ai/sdk`: 0.54.0
- `@aws-sdk/client-bedrock-runtime`: 3.830.0
- `openai`: 5.5.1
- Various dev dependencies updated

### CI/CD Improvements
- Added test execution to publish workflow before npm publish
- Updated test scripts:
  - `npm test`: Now runs tests once and exits
  - `npm run test:watch`: Added for continuous testing during development

### Other Changes
- Version bumped to 1.4.1
- Fixed instructions parameter placement in convertToLlamaPrompt calls

## Breaking Changes
None

## Test Plan
- [x] All existing tests pass
- [x] New tests for Llama prompt conversion added
- [x] Manual testing with Llama 4 models
- [ ] Verify publish workflow runs tests before publishing
- [ ] Verify new test scripts work as expected